### PR TITLE
Versoin 20180405-1230

### DIFF
--- a/jd-autoclose-ticket/extension.xml
+++ b/jd-autoclose-ticket/extension.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension format="1.0">
+	<extension_code>jd-autoclose-ticket</extension_code>
+	<company></company>
+	<author><![CDATA[jdefoort]]></author>
+	<label><![CDATA[Autoclose Ticket]]></label>
+	<description><![CDATA[Automatically close resolved Rcx Request, User Request and Incident tickets]]></description>
+	<version>2.4.180405</version>
+	<release_date>2018-04-05</release_date>
+	<version_description><![CDATA[ ]]></version_description>
+	<itop_version_min></itop_version_min>
+	<status></status>
+	<mandatory>false</mandatory>
+	<more_info_url></more_info_url>
+</extension>

--- a/jd-autoclose-ticket/module.jd-autoclose-ticket.php
+++ b/jd-autoclose-ticket/module.jd-autoclose-ticket.php
@@ -16,7 +16,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'jd-autoclose-ticket/1.0.1',
+	'jd-autoclose-ticket/2.4.180504',
 	array(
 		// Identification
 		//

--- a/jd-class-vehicle/en.dict.jb-class-monitor.php
+++ b/jd-class-vehicle/en.dict.jb-class-monitor.php
@@ -8,23 +8,41 @@
 
 Dict::Add('EN US', 'English', 'English', array(
 	// Dictionary entries go here
-	'Class:Monitor' => 'Monitor',
-	'Class:Monitor+' => 'A computer display',
-	'Class:Monitor/Attribute:technology' => 'Technology',
-	'Class:Monitor/Attribute:technology+' => 'Technology used for the display',
-	'Class:Monitor/Attribute:technology/Value:crt' => 'CRT',
-	'Class:Monitor/Attribute:technology/Value:lcd' => 'LCD', 
+	'Class:Vehicle' => 'Vehicle',
+	'Class:Vehicle+' => 'Vehicles such as cars and trucks',
+	'Class:Vehicle/Attribute:energysource' => 'Energy source',
+	'Class:Vehicle/Attribute:energysource+' => 'Fuel or energy source',
+	'Class:Vehicle/Attribute:energysource/Value:diesel' => 'Diesel',
+	'Class:Vehicle/Attribute:energysource/Value:euro95' => 'Euro 95',
+	'Class:Vehicle/Attribute:energysource/Value:euro98' => 'Euro 98',
+	'Class:Vehicle/Attribute:energysource/Value:CNG' => 'CNG',
+	'Class:Vehicle/Attribute:energysource/Value:LPG' => 'LPG',
+	'Class:Vehicle/Attribute:energysource/Value:electrical' => 'Electrical',
+	'Class:Vehicle/Attribute:energysource/Value:twostroke' => 'Two-stroke',
 	
-	'Class:Monitor/Attribute:numVGA' => 'VGA Ports',
-	'Class:Monitor/Attribute:numVGA+' => 'Number of VGA ports',
-	'Class:Monitor/Attribute:numHDMI' => 'HDMI Ports',
-	'Class:Monitor/Attribute:numHDMI+' => 'Number of HDMI ports',
-	'Class:Monitor/Attribute:numDisplayPort' => 'Display Ports',
-	'Class:Monitor/Attribute:numDisplayPort+' => 'Number of Display ports',
+	'Class:Vehicle/Attribute:driverslicense' => 'Driver\'s license',
+	'Class:Vehicle/Attribute:driverslicense+' => 'Required driver\'s license to operate this vehicle',
+
 	
+	'Class:Vehicle/Attribute:maintenanceplace' => 'Maintenance place',
+	'Class:Vehicle/Attribute:maintenanceplace+' => 'The maintenance place for this vehicle',
+	'Class:Vehicle/Attribute:payload' => 'Payload',
+	'Class:Vehicle/Attribute:payload+' => 'The payload for this vehicle',
+	'Class:Vehicle/Attribute:vehiclepicture' => 'Vehicle picture',
+	'Class:Vehicle/Attribute:vehiclepicture+' => 'Upload a clear picture of the vehicle',
 	
-	'Class:Model/Attribute:type/Value:Monitor' => 'Monitor',
-	'Class:Model/Attribute:type/Value:Monitor+' => 'Monitor',
+	'Class:Vehicle/Attribute:licenseplate' => 'License plate',
+	'Class:Vehicle/Attribute:licenseplate+' => 'License plate',
+	'Class:Vehicle/Attribute:chassisnumber' => 'Chassis number',
+	'Class:Vehicle/Attribute:chassisnumber+' => 'Chassis number',
+	
+	'Class:Vehicle/Attribute:nextmaintenance' => 'Next planned maintenance',
+	'Class:Vehicle/Attribute:nextmaintenance+' => 'Date of next planned maintenance',
+	'Class:Vehicle/Attribute:nextinspection' => 'Next planned inspection',
+	'Class:Vehicle/Attribute:nextinspection+' => 'Date of next planned inspection',
+	'Class:Vehicle/Attribute:insuredtill' => 'Insured until',
+	'Class:Vehicle/Attribute:insuredtill+' => 'Date of insurance renewal/expiration',
+
 ));
 
  


### PR DESCRIPTION
jd-autoclose-ticket:
- added extension.xml
- changed version numbering
- looked at the wrong settings (default Combodo AutoClose)
- fixed $aReport which was set to an empty array at a wrong location
- made it more efficient to add Ticket types, since it all works the same anyhow right now.